### PR TITLE
✨ feat: 이벤트 수정 로직 개발, 테스트 코드 작성

### DIFF
--- a/src/main/java/com/hhplus/project/domain/event/Event.java
+++ b/src/main/java/com/hhplus/project/domain/event/Event.java
@@ -1,55 +1,40 @@
 package com.hhplus.project.domain.event;
 
 import com.hhplus.project.domain.event.dto.UpdateEvent;
-import com.hhplus.project.infra.event.entity.RecurringRulesEntity;
-import lombok.Getter;
+import com.hhplus.project.support.BaseException;
 
 import java.time.LocalDateTime;
 
-@Getter
-public class Event {
-    /** 스터디 id */
-    private Long eventId;
-
-    /** 카테고리 id */
-    private Long categoryId;
-
-    /** 지역 id */
-    private Long locationId;
-
-    /** 스터디명 */
-    private String name;
-
-    /** 스터디 내용 */
-    private String content;
-
-    /** 스터디 시작시간 */
-    private LocalDateTime startAt;
-
-    /** 스터디 종료시간 */
-    private LocalDateTime endAt;
-
-    /** 스터디 주최자 (member_id) */
-    private Long hostId;
-
-    /** 정원 */
-    private int capacity;
-
-    /** 이벤트 승인 타입 */
-    private EventEnums.ApproveType approveType;
-
-    /** 온라인 여부 */
-    private boolean isOnline;
-
-    /** 상세 장소 */
-    private String locationDetail;
-
-    /** 스터디 반복 규칙 */
-    private RecurringRulesEntity recurringRules;
-
-    /** 삭제일시 */
-    private LocalDateTime deletedAt;
-
+public record Event(
+        /** 스터디 id */
+        Long eventId,
+        /** 카테고리 id */
+         Long categoryId,
+        /** 지역 id */
+         Long locationId,
+        /** 스터디명 */
+         String name,
+        /** 스터디 내용 */
+         String content,
+        /** 스터디 시작시간 */
+         LocalDateTime startAt,
+        /** 스터디 종료시간 */
+         LocalDateTime endAt,
+        /** 스터디 주최자 (member_id) */
+         Long hostId,
+        /** 정원 */
+         int capacity,
+        /** 이벤트 승인 타입 */
+         EventEnums.ApproveType approveType,
+        /** 온라인 여부 */
+         boolean isOnline,
+        /** 상세 장소 */
+         String locationDetail,
+        /** 스터디 반복 규칙 */
+         RecurringRules recurringRules,
+        /** 삭제일시 */
+         LocalDateTime deletedAt
+) {
     public static Event create(
             Long eventId,
             Long categoryId,
@@ -63,30 +48,48 @@ public class Event {
             EventEnums.ApproveType approveType,
             boolean isOnline,
             String locationDetail,
-            RecurringRulesEntity recurringRules,
+            RecurringRules recurringRules,
             LocalDateTime deletedAt
     ) {
-        Event event = new Event();
-        event.eventId = eventId;
-        event.categoryId = categoryId;
-        event.locationId = locationId;
-        event.name = name;
-        event.content = content;
-        event.startAt = startAt;
-        event.endAt = endAt;
-        event.hostId = hostId;
-        event.capacity = capacity;
-        event.approveType = approveType;
-        event.isOnline = isOnline;
-        event.locationDetail = locationDetail;
-        event.recurringRules = recurringRules;
-        event.deletedAt = deletedAt;
-        return event;
+        return new Event(eventId,
+                categoryId,
+                locationId,
+                name,
+                content,
+                startAt,
+                endAt,
+                hostId,
+                capacity,
+                approveType,
+                isOnline,
+                locationDetail,
+                recurringRules,
+                deletedAt
+        );
     }
 
-    public void updateChangeData(UpdateEvent.Criteria criteria, String imagePath) {
-        // 여기서 기간으로 변경 가능 데이터 인지, 아닌지 체크하기
+    public Event update(UpdateEvent.Command command, RecurringRules recurringRules) {
+        // 이미 종료된 이벤트라면 예외 발생
+        if(this.endAt().isBefore(LocalDateTime.now())) {
+            throw new BaseException(EventException.ALREADY_ENDED_EVENT);
+        }
 
-        // 여기서 변경된 데이터를 세팅
+        // 이벤트 업데이트
+        return Event.create(
+                command.eventId(),
+                command.categoryId(),
+                command.locationId(),
+                command.name(),
+                command.content(),
+                command.startAt(),
+                command.endAt(),
+                this.hostId,
+                command.capacity(),
+                command.approveType(),
+                command.isOnline(),
+                command.locationDetail(),
+                recurringRules,
+                this.deletedAt
+        );
     }
 }

--- a/src/main/java/com/hhplus/project/domain/event/Event.java
+++ b/src/main/java/com/hhplus/project/domain/event/Event.java
@@ -1,0 +1,92 @@
+package com.hhplus.project.domain.event;
+
+import com.hhplus.project.domain.event.dto.UpdateEvent;
+import com.hhplus.project.infra.event.entity.RecurringRulesEntity;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Event {
+    /** 스터디 id */
+    private Long eventId;
+
+    /** 카테고리 id */
+    private Long categoryId;
+
+    /** 지역 id */
+    private Long locationId;
+
+    /** 스터디명 */
+    private String name;
+
+    /** 스터디 내용 */
+    private String content;
+
+    /** 스터디 시작시간 */
+    private LocalDateTime startAt;
+
+    /** 스터디 종료시간 */
+    private LocalDateTime endAt;
+
+    /** 스터디 주최자 (member_id) */
+    private Long hostId;
+
+    /** 정원 */
+    private int capacity;
+
+    /** 이벤트 승인 타입 */
+    private EventEnums.ApproveType approveType;
+
+    /** 온라인 여부 */
+    private boolean isOnline;
+
+    /** 상세 장소 */
+    private String locationDetail;
+
+    /** 스터디 반복 규칙 */
+    private RecurringRulesEntity recurringRules;
+
+    /** 삭제일시 */
+    private LocalDateTime deletedAt;
+
+    public static Event create(
+            Long eventId,
+            Long categoryId,
+            Long locationId,
+            String name,
+            String content,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            Long hostId,
+            int capacity,
+            EventEnums.ApproveType approveType,
+            boolean isOnline,
+            String locationDetail,
+            RecurringRulesEntity recurringRules,
+            LocalDateTime deletedAt
+    ) {
+        Event event = new Event();
+        event.eventId = eventId;
+        event.categoryId = categoryId;
+        event.locationId = locationId;
+        event.name = name;
+        event.content = content;
+        event.startAt = startAt;
+        event.endAt = endAt;
+        event.hostId = hostId;
+        event.capacity = capacity;
+        event.approveType = approveType;
+        event.isOnline = isOnline;
+        event.locationDetail = locationDetail;
+        event.recurringRules = recurringRules;
+        event.deletedAt = deletedAt;
+        return event;
+    }
+
+    public void updateChangeData(UpdateEvent.Criteria criteria, String imagePath) {
+        // 여기서 기간으로 변경 가능 데이터 인지, 아닌지 체크하기
+
+        // 여기서 변경된 데이터를 세팅
+    }
+}

--- a/src/main/java/com/hhplus/project/domain/event/EventException.java
+++ b/src/main/java/com/hhplus/project/domain/event/EventException.java
@@ -9,6 +9,8 @@ import lombok.RequiredArgsConstructor;
 public enum EventException implements ExceptionInterface {
 
     SAMPLE("EVENT.EXCEPTION.SAMPLE", "에러 샘플"),
+    ALREADY_ENDED_EVENT("ALREADY.ENDED.EVENT", "이미 종료된 이벤트입니다."),
+    NOT_EXISTS_EVENT("NOT.EXISTS.EVENT", "이벤트가 존재하지 않습니다."),
     ;
 
     private final String code;

--- a/src/main/java/com/hhplus/project/domain/event/EventRepository.java
+++ b/src/main/java/com/hhplus/project/domain/event/EventRepository.java
@@ -1,7 +1,8 @@
 package com.hhplus.project.domain.event;
 
 public interface EventRepository {
-    Event findById(Long eventId);
 
-    void save(Event event);
+    Event save(Event event);
+
+    Event getEvent(Long aLong);
 }

--- a/src/main/java/com/hhplus/project/domain/event/EventRepository.java
+++ b/src/main/java/com/hhplus/project/domain/event/EventRepository.java
@@ -1,0 +1,7 @@
+package com.hhplus.project.domain.event;
+
+public interface EventRepository {
+    Event findById(Long eventId);
+
+    void save(Event event);
+}

--- a/src/main/java/com/hhplus/project/domain/event/EventService.java
+++ b/src/main/java/com/hhplus/project/domain/event/EventService.java
@@ -1,25 +1,26 @@
 package com.hhplus.project.domain.event;
 
 import com.hhplus.project.domain.event.dto.UpdateEvent;
-import com.hhplus.project.domain.utils.ImageUploadUtil;
-import jakarta.transaction.Transactional; 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
 public class EventService {
 
     private final EventRepository eventRepository;
-    private final ImageUploadUtil imageUploadUtil;
 
     @Transactional
-    public void update(UpdateEvent.Criteria criteria, MultipartFile file) {
-        Event event = eventRepository.findById(criteria.eventId()); // 영속성 컨테스트 안에 없음
-        // TODO - MultipartFile -> File로 변환해야함
-        String imagePath = imageUploadUtil.upload(file);
-        event.updateChangeData(criteria, imagePath);
-        eventRepository.save(event);
+    public Event update(UpdateEvent.Command command) {
+        // 이벤트 조회
+        Event event = eventRepository.getEvent(command.eventId());
+        // 이벤트 도메인 모델 정보 변경
+        Event updatedEvent = event.update(command, null);
+
+        // TODO 반복룰 설계 수정 후 구현
+        // TODO 파사드에서 이미지 서비스 만들어서 처리하기
+
+        return eventRepository.save(updatedEvent);
     }
 }

--- a/src/main/java/com/hhplus/project/domain/event/EventService.java
+++ b/src/main/java/com/hhplus/project/domain/event/EventService.java
@@ -1,0 +1,25 @@
+package com.hhplus.project.domain.event;
+
+import com.hhplus.project.domain.event.dto.UpdateEvent;
+import com.hhplus.project.domain.utils.ImageUploadUtil;
+import jakarta.transaction.Transactional; 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@RequiredArgsConstructor
+@Service
+public class EventService {
+
+    private final EventRepository eventRepository;
+    private final ImageUploadUtil imageUploadUtil;
+
+    @Transactional
+    public void update(UpdateEvent.Criteria criteria, MultipartFile file) {
+        Event event = eventRepository.findById(criteria.eventId()); // 영속성 컨테스트 안에 없음
+        // TODO - MultipartFile -> File로 변환해야함
+        String imagePath = imageUploadUtil.upload(file);
+        event.updateChangeData(criteria, imagePath);
+        eventRepository.save(event);
+    }
+}

--- a/src/main/java/com/hhplus/project/domain/event/dto/UpdateEvent.java
+++ b/src/main/java/com/hhplus/project/domain/event/dto/UpdateEvent.java
@@ -1,4 +1,4 @@
-package com.hhplus.project.interfaces.event;
+package com.hhplus.project.domain.event.dto;
 
 import com.hhplus.project.domain.event.EventEnums;
 import com.hhplus.project.domain.event.RecurringRulesEnums;
@@ -7,10 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public record UpdateEvent(
-
-) {
-    public record Request(
+public record UpdateEvent() {
+    public record Criteria(
+            @Schema(description = "이벤트 id", example = "1")
+            Long eventId,
             @Schema(description = "카테고리 id", example = "123")
             Long categoryId,
             @Schema(description = "이벤트명", example = "서각코 모집")
@@ -34,17 +34,21 @@ public record UpdateEvent(
             @Schema(description = "반복 설정 정보")
             RecurringRules recurringRules
     ) {
-        public com.hhplus.project.domain.event.dto.UpdateEvent.Criteria toCriteria(Long eventId) {
-            com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules rules =
-                    com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules.create(
-                            recurringRules.recurringRulesId,
-                            recurringRules.recurringType,
-                            recurringRules.recurringInterval,
-                            recurringRules.startAt,
-                            recurringRules.endAt
-                    );
-
-            return com.hhplus.project.domain.event.dto.UpdateEvent.Criteria.create(
+        public static Criteria create(
+                Long eventId,
+                Long categoryId,
+                String name,
+                String content,
+                LocalDateTime startAt,
+                LocalDateTime endAt,
+                int capacity,
+                EventEnums.ApproveType approveType,
+                boolean isOnline,
+                Long locationId,
+                String locationDetail,
+                RecurringRules recurringRules
+        ) {
+            return new Criteria(
                     eventId,
                     categoryId,
                     name,
@@ -56,9 +60,10 @@ public record UpdateEvent(
                     isOnline,
                     locationId,
                     locationDetail,
-                    rules
-                    );
+                    recurringRules
+            );
         }
+
     }
 
     public record RecurringRules(
@@ -72,5 +77,21 @@ public record UpdateEvent(
             LocalDate startAt,
             @Schema(description = "반복 종료일", example = "2025-06-10")
             LocalDate endAt
-    ) {}
+    ) {
+        public static RecurringRules create(
+                Long recurringRulesId,
+                RecurringRulesEnums.Type recurringType,
+                int recurringInterval,
+                LocalDate startAt,
+                LocalDate endAt
+        ) {
+            return new RecurringRules(
+                    recurringRulesId,
+                    recurringType,
+                    recurringInterval,
+                    startAt,
+                    endAt
+            );
+        }
+    }
 }

--- a/src/main/java/com/hhplus/project/domain/event/dto/UpdateEvent.java
+++ b/src/main/java/com/hhplus/project/domain/event/dto/UpdateEvent.java
@@ -3,12 +3,13 @@ package com.hhplus.project.domain.event.dto;
 import com.hhplus.project.domain.event.EventEnums;
 import com.hhplus.project.domain.event.RecurringRulesEnums;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record UpdateEvent() {
-    public record Criteria(
+    public record Command(
             @Schema(description = "이벤트 id", example = "1")
             Long eventId,
             @Schema(description = "카테고리 id", example = "123")
@@ -31,10 +32,12 @@ public record UpdateEvent() {
             Long locationId,
             @Schema(description = "상세 장소", example = "스타벅스 XX지점")
             String locationDetail,
+            @Schema(description = "이벤트 이미지", example = "파일 업로드 예: event.jpg")
+            MultipartFile imageFile,
             @Schema(description = "반복 설정 정보")
             RecurringRules recurringRules
     ) {
-        public static Criteria create(
+        public static Command create(
                 Long eventId,
                 Long categoryId,
                 String name,
@@ -46,9 +49,10 @@ public record UpdateEvent() {
                 boolean isOnline,
                 Long locationId,
                 String locationDetail,
+                MultipartFile imageFile,
                 RecurringRules recurringRules
         ) {
-            return new Criteria(
+            return new Command(
                     eventId,
                     categoryId,
                     name,
@@ -60,6 +64,7 @@ public record UpdateEvent() {
                     isOnline,
                     locationId,
                     locationDetail,
+                    imageFile,
                     recurringRules
             );
         }
@@ -74,23 +79,23 @@ public record UpdateEvent() {
             @Schema(description = "반복 주기 (몇 주마다 등)", example = "1")
             int recurringInterval,
             @Schema(description = "반복 시작일", example = "2025-04-10")
-            LocalDate startAt,
+            LocalDate startDate,
             @Schema(description = "반복 종료일", example = "2025-06-10")
-            LocalDate endAt
+            LocalDate endDate
     ) {
         public static RecurringRules create(
                 Long recurringRulesId,
                 RecurringRulesEnums.Type recurringType,
                 int recurringInterval,
-                LocalDate startAt,
-                LocalDate endAt
+                LocalDate startDate,
+                LocalDate endDate
         ) {
             return new RecurringRules(
                     recurringRulesId,
                     recurringType,
                     recurringInterval,
-                    startAt,
-                    endAt
+                    startDate,
+                    endDate
             );
         }
     }

--- a/src/main/java/com/hhplus/project/domain/utils/ImageUploadUtil.java
+++ b/src/main/java/com/hhplus/project/domain/utils/ImageUploadUtil.java
@@ -1,0 +1,10 @@
+package com.hhplus.project.domain.utils;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public interface ImageUploadUtil {
+
+    String upload(MultipartFile file);
+}

--- a/src/main/java/com/hhplus/project/infra/event/entity/EventEntity.java
+++ b/src/main/java/com/hhplus/project/infra/event/entity/EventEntity.java
@@ -1,13 +1,20 @@
 package com.hhplus.project.infra.event.entity;
 
 import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.domain.event.RecurringRules;
 import com.hhplus.project.infra.BaseTimeEntity;
 import com.hhplus.project.domain.event.EventEnums;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "event")
 public class EventEntity extends BaseTimeEntity {
     /** 스터디 id */
     @Id
@@ -102,7 +109,6 @@ public class EventEntity extends BaseTimeEntity {
     }
 
     public static EventEntity create(
-            Long eventId,
             Long categoryId,
             Long locationId,
             String name,
@@ -118,7 +124,7 @@ public class EventEntity extends BaseTimeEntity {
             LocalDateTime deletedAt
     ) {
         return new EventEntity(
-                eventId,
+                null,
                 categoryId,
                 locationId,
                 name,
@@ -135,19 +141,6 @@ public class EventEntity extends BaseTimeEntity {
         );
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        EventEntity event = (EventEntity) o;
-        return Objects.equals(eventId, event.eventId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(eventId);
-    }
-
     public Event toDomain() {
         return Event.create(
                 this.eventId,
@@ -162,27 +155,55 @@ public class EventEntity extends BaseTimeEntity {
                 this.approveType,
                 this.isOnline,
                 this.locationDetail,
-                this.recurringRules,
+                null,
                 this.deletedAt
         );
     }
 
-    public static EventEntity fromDomain(Event event) {
+    public static EventEntity fromDomain(Event event, RecurringRulesEntity recurringRulesEntity) {
         return EventEntity.create(
-                event.getEventId(),
-                event.getCategoryId(),
-                event.getLocationId(),
-                event.getName(),
-                event.getContent(),
-                event.getStartAt(),
-                event.getEndAt(),
-                event.getHostId(),
-                event.getCapacity(),
-                event.getApproveType(),
+                event.categoryId(),
+                event.locationId(),
+                event.name(),
+                event.content(),
+                event.startAt(),
+                event.endAt(),
+                event.hostId(),
+                event.capacity(),
+                event.approveType(),
                 event.isOnline(),
-                event.getLocationDetail(),
-                event.getRecurringRules(),
-                event.getDeletedAt()
+                event.locationDetail(),
+                recurringRulesEntity,
+                event.deletedAt()
         );
+    }
+
+    public void update(Event event, RecurringRules recurringRules) {
+        // 이벤트 업데이트
+        this.categoryId = event.categoryId();
+        this.locationId = event.locationId();
+        this.name = event.name();
+        this.content = event.content();
+        this.startAt = event.startAt();
+        this.endAt = event.endAt();
+        this.capacity = event.capacity();
+        this.approveType = event.approveType();
+        this.isOnline = event.isOnline();
+        this.locationDetail = event.locationDetail();
+        this.recurringRules = ObjectUtils.isEmpty(recurringRules) ?
+                null : RecurringRulesEntity.fromDomain(recurringRules);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EventEntity event = (EventEntity) o;
+        return Objects.equals(eventId, event.eventId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId);
     }
 }

--- a/src/main/java/com/hhplus/project/infra/event/entity/EventEntity.java
+++ b/src/main/java/com/hhplus/project/infra/event/entity/EventEntity.java
@@ -1,5 +1,6 @@
 package com.hhplus.project.infra.event.entity;
 
+import com.hhplus.project.domain.event.Event;
 import com.hhplus.project.infra.BaseTimeEntity;
 import com.hhplus.project.domain.event.EventEnums;
 import jakarta.persistence.*;
@@ -7,8 +8,6 @@ import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-@Entity
-@Table(name = "event")
 public class EventEntity extends BaseTimeEntity {
     /** 스터디 id */
     @Id
@@ -71,6 +70,71 @@ public class EventEntity extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    private EventEntity(Long eventId,
+                       Long categoryId,
+                       Long locationId,
+                       String name,
+                       String content,
+                       LocalDateTime startAt,
+                       LocalDateTime endAt,
+                       Long hostId,
+                       int capacity,
+                       EventEnums.ApproveType approveType,
+                       boolean isOnline,
+                       String locationDetail,
+                       RecurringRulesEntity recurringRules,
+                       LocalDateTime deletedAt
+    ) {
+        this.eventId = eventId;
+        this.categoryId = categoryId;
+        this.locationId = locationId;
+        this.name = name;
+        this.content = content;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.hostId = hostId;
+        this.capacity = capacity;
+        this.approveType = approveType;
+        this.isOnline = isOnline;
+        this.locationDetail = locationDetail;
+        this.recurringRules = recurringRules;
+        this.deletedAt = deletedAt;
+    }
+
+    public static EventEntity create(
+            Long eventId,
+            Long categoryId,
+            Long locationId,
+            String name,
+            String content,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            Long hostId,
+            int capacity,
+            EventEnums.ApproveType approveType,
+            boolean isOnline,
+            String locationDetail,
+            RecurringRulesEntity recurringRules,
+            LocalDateTime deletedAt
+    ) {
+        return new EventEntity(
+                eventId,
+                categoryId,
+                locationId,
+                name,
+                content,
+                startAt,
+                endAt,
+                hostId,
+                capacity,
+                approveType,
+                isOnline,
+                locationDetail,
+                recurringRules,
+                deletedAt
+        );
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -82,5 +146,43 @@ public class EventEntity extends BaseTimeEntity {
     @Override
     public int hashCode() {
         return Objects.hash(eventId);
+    }
+
+    public Event toDomain() {
+        return Event.create(
+                this.eventId,
+                this.categoryId,
+                this.locationId,
+                this.name,
+                this.content,
+                this.startAt,
+                this.endAt,
+                this.hostId,
+                this.capacity,
+                this.approveType,
+                this.isOnline,
+                this.locationDetail,
+                this.recurringRules,
+                this.deletedAt
+        );
+    }
+
+    public static EventEntity fromDomain(Event event) {
+        return EventEntity.create(
+                event.getEventId(),
+                event.getCategoryId(),
+                event.getLocationId(),
+                event.getName(),
+                event.getContent(),
+                event.getStartAt(),
+                event.getEndAt(),
+                event.getHostId(),
+                event.getCapacity(),
+                event.getApproveType(),
+                event.isOnline(),
+                event.getLocationDetail(),
+                event.getRecurringRules(),
+                event.getDeletedAt()
+        );
     }
 }

--- a/src/main/java/com/hhplus/project/infra/event/entity/RecurringRulesEntity.java
+++ b/src/main/java/com/hhplus/project/infra/event/entity/RecurringRulesEntity.java
@@ -1,13 +1,17 @@
 package com.hhplus.project.infra.event.entity;
 
+import com.hhplus.project.domain.event.RecurringRules;
 import com.hhplus.project.infra.BaseTimeEntity;
 import com.hhplus.project.domain.event.RecurringRulesEnums;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Table(name = "recurring_rules")
 public class RecurringRulesEntity extends BaseTimeEntity {
@@ -37,6 +41,60 @@ public class RecurringRulesEntity extends BaseTimeEntity {
     /** 삭제일시 */
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    private RecurringRulesEntity(Long recurringRulesId,
+                                 RecurringRulesEnums.Type recurringType,
+                                 int recurringInterval,
+                                 LocalDate startDate,
+                                 LocalDate endDate,
+                                 LocalDateTime deletedAt
+    ) {
+        this.recurringRulesId = recurringRulesId;
+        this.recurringType = recurringType;
+        this.recurringInterval = recurringInterval;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.deletedAt = deletedAt;
+    }
+    public static RecurringRulesEntity create(
+            Long recurringRulesId,
+            RecurringRulesEnums.Type recurringType,
+            int recurringInterval,
+            LocalDate startDate,
+            LocalDate endDate,
+            LocalDateTime deletedAt
+    ) {
+        return new RecurringRulesEntity(
+                recurringRulesId,
+                recurringType,
+                recurringInterval,
+                startDate,
+                endDate,
+                deletedAt
+        );
+    }
+
+    public RecurringRules toDomain() {
+        return RecurringRules.create(
+                this.recurringRulesId,
+                this.recurringType,
+                this.recurringInterval,
+                this.startDate,
+                this.endDate,
+                this.deletedAt
+        );
+    }
+
+    public static RecurringRulesEntity fromDomain(RecurringRules recurringRules) {
+        return RecurringRulesEntity.create(
+                recurringRules.recurringRulesId(),
+                recurringRules.recurringType(),
+                recurringRules.recurringInterval(),
+                recurringRules.startDate(),
+                recurringRules.endDate(),
+                recurringRules.deletedAt()
+        );
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/hhplus/project/infra/event/repository/EventJpaRepository.java
+++ b/src/main/java/com/hhplus/project/infra/event/repository/EventJpaRepository.java
@@ -5,5 +5,5 @@ import com.hhplus.project.infra.event.entity.EventEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EventJpaRepository extends JpaRepository<EventEntity, Long> {
-    Event save(EventEntity eventEntity);
+    EventEntity save(EventEntity eventEntity);
 }

--- a/src/main/java/com/hhplus/project/infra/event/repository/EventJpaRepository.java
+++ b/src/main/java/com/hhplus/project/infra/event/repository/EventJpaRepository.java
@@ -1,0 +1,9 @@
+package com.hhplus.project.infra.event.repository;
+
+import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.infra.event.entity.EventEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventJpaRepository extends JpaRepository<EventEntity, Long> {
+    Event save(EventEntity eventEntity);
+}

--- a/src/main/java/com/hhplus/project/infra/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/hhplus/project/infra/event/repository/EventRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.hhplus.project.infra.event.repository;
+
+import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.domain.event.EventRepository;
+import com.hhplus.project.infra.event.entity.EventEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class EventRepositoryImpl implements EventRepository {
+
+    private final EventJpaRepository jpaRepository;
+
+    @Override
+    public Event findById(Long eventId) {
+        EventEntity eventEntity = jpaRepository.findById(eventId).orElseThrow(RuntimeException::new);
+        return eventEntity.toDomain();
+    }
+
+    @Override
+    public void save(Event event) {
+        jpaRepository.save(EventEntity.fromDomain(event));
+    }
+}

--- a/src/main/java/com/hhplus/project/infra/event/repository/EventRepositoryImpl.java
+++ b/src/main/java/com/hhplus/project/infra/event/repository/EventRepositoryImpl.java
@@ -1,8 +1,10 @@
 package com.hhplus.project.infra.event.repository;
 
 import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.domain.event.EventException;
 import com.hhplus.project.domain.event.EventRepository;
 import com.hhplus.project.infra.event.entity.EventEntity;
+import com.hhplus.project.support.BaseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,16 +12,17 @@ import org.springframework.stereotype.Repository;
 @Repository
 public class EventRepositoryImpl implements EventRepository {
 
-    private final EventJpaRepository jpaRepository;
-
+    private final EventJpaRepository eventJpaRepository;
     @Override
-    public Event findById(Long eventId) {
-        EventEntity eventEntity = jpaRepository.findById(eventId).orElseThrow(RuntimeException::new);
+    public Event getEvent(Long eventId) {
+        EventEntity eventEntity = eventJpaRepository.findById(eventId).orElseThrow(() -> new BaseException(EventException.NOT_EXISTS_EVENT));
         return eventEntity.toDomain();
     }
 
     @Override
-    public void save(Event event) {
-        jpaRepository.save(EventEntity.fromDomain(event));
+    public Event save(Event event) {
+        EventEntity eventEntity = eventJpaRepository.findById(event.eventId()).orElseThrow(() -> new BaseException(EventException.NOT_EXISTS_EVENT));
+        eventEntity.update(event, null);
+        return eventJpaRepository.save(eventEntity).toDomain();
     }
 }

--- a/src/main/java/com/hhplus/project/infra/utils/ImageUploadUtilImpl.java
+++ b/src/main/java/com/hhplus/project/infra/utils/ImageUploadUtilImpl.java
@@ -1,0 +1,12 @@
+package com.hhplus.project.infra.utils;
+
+import com.hhplus.project.domain.utils.ImageUploadUtil;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ImageUploadUtilImpl implements ImageUploadUtil {
+
+    @Override
+    public String upload(MultipartFile file) {
+        return null;
+    }
+}

--- a/src/main/java/com/hhplus/project/interfaces/event/EventController.java
+++ b/src/main/java/com/hhplus/project/interfaces/event/EventController.java
@@ -1,5 +1,6 @@
 package com.hhplus.project.interfaces.event;
 
+import com.hhplus.project.domain.event.EventService;
 import com.hhplus.project.support.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -18,6 +19,8 @@ import java.util.List;
 @RequestMapping("/events")
 public class EventController {
 
+    private final EventService eventService;
+
     @Operation(summary = "이벤트 상세조회 API", description = "이벤트 상세 정보를 반환합니다.")
     @GetMapping("/{eventId}")
     public ApiResponse<EventDetail.Response> getEventDetail(@Parameter(description = "이벤트ID") @PathVariable long eventId
@@ -35,8 +38,12 @@ public class EventController {
     }
 
     @Operation(summary = "이벤트 수정 API", description = "이벤트 정보를 수정합니다.")
-    @PatchMapping("/{eventId}")
-    public ApiResponse<Void> updateEvent(@Parameter(description = "이벤트ID") @PathVariable Long eventId, @Parameter(description = "이벤트 변경 정보") @RequestBody UpdateEvent.Request request) {
+    @PatchMapping(path = "/{eventId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<Void> updateEvent(
+            @Parameter(description = "이벤트ID") @PathVariable Long eventId
+          , @Parameter(description = "이벤트 변경 정보") @RequestBody UpdateEvent.Request request
+          , @Parameter(description = "이벤트 썸네일 파일")  @RequestPart(value = "image",required = false) MultipartFile imageFile) {
+        eventService.update(request.toCriteria(eventId), imageFile);
         return ApiResponse.ok();
     }
 

--- a/src/main/java/com/hhplus/project/interfaces/event/EventController.java
+++ b/src/main/java/com/hhplus/project/interfaces/event/EventController.java
@@ -41,9 +41,9 @@ public class EventController {
     @PatchMapping(path = "/{eventId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> updateEvent(
             @Parameter(description = "이벤트ID") @PathVariable Long eventId
-          , @Parameter(description = "이벤트 변경 정보") @RequestBody UpdateEvent.Request request
-          , @Parameter(description = "이벤트 썸네일 파일")  @RequestPart(value = "image",required = false) MultipartFile imageFile) {
-        eventService.update(request.toCriteria(eventId), imageFile);
+            , @Parameter(description = "이벤트 변경 정보") @RequestPart UpdateEvent.Request request
+            , @Parameter(description = "이벤트 썸네일 파일") @RequestPart(value = "image",required = false) MultipartFile imageFile) {
+        // eventService.update(request.toCommand(eventId, imageFile));
         return ApiResponse.ok();
     }
 

--- a/src/main/java/com/hhplus/project/interfaces/event/UpdateEvent.java
+++ b/src/main/java/com/hhplus/project/interfaces/event/UpdateEvent.java
@@ -3,6 +3,8 @@ package com.hhplus.project.interfaces.event;
 import com.hhplus.project.domain.event.EventEnums;
 import com.hhplus.project.domain.event.RecurringRulesEnums;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,40 +13,44 @@ public record UpdateEvent(
 
 ) {
     public record Request(
+            @NotNull
             @Schema(description = "카테고리 id", example = "123")
             Long categoryId,
+            @NotNull
             @Schema(description = "이벤트명", example = "서각코 모집")
             String name,
+            @NotNull
             @Schema(description = "스터디 내용", example = "스타벅스에서 모각코 하실 분!")
             String content,
+            @NotNull
             @Schema(description = "이벤트 시작 일시", example = "2025-04-10T14:00:00")
             LocalDateTime startAt,
+            @NotNull
             @Schema(description = "이벤트 종료 일시", example = "2025-04-10T16:00:00")
             LocalDateTime endAt,
+            @NotNull
             @Schema(description = "정원", example = "30")
             int capacity,
+            @NotNull
             @Schema(description = "승인 타입 (AUTO: 자동, MANUAL: 수동)", example = "AUTO")
             EventEnums.ApproveType approveType,
+            @NotNull
             @Schema(description = "온라인 여부", example = "false")
             boolean isOnline,
+
             @Schema(description = "지역 id", example = "12")
             Long locationId,
+            @NotNull
             @Schema(description = "상세 장소", example = "스타벅스 XX지점")
             String locationDetail,
             @Schema(description = "반복 설정 정보")
             RecurringRules recurringRules
     ) {
-        public com.hhplus.project.domain.event.dto.UpdateEvent.Criteria toCriteria(Long eventId) {
+        public com.hhplus.project.domain.event.dto.UpdateEvent.Command toCommand(Long eventId, MultipartFile imageFile) {
             com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules rules =
-                    com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules.create(
-                            recurringRules.recurringRulesId,
-                            recurringRules.recurringType,
-                            recurringRules.recurringInterval,
-                            recurringRules.startAt,
-                            recurringRules.endAt
-                    );
+                    recurringRules.toCommand();
 
-            return com.hhplus.project.domain.event.dto.UpdateEvent.Criteria.create(
+            return com.hhplus.project.domain.event.dto.UpdateEvent.Command.create(
                     eventId,
                     categoryId,
                     name,
@@ -56,6 +62,7 @@ public record UpdateEvent(
                     isOnline,
                     locationId,
                     locationDetail,
+                    imageFile,
                     rules
                     );
         }
@@ -69,8 +76,19 @@ public record UpdateEvent(
             @Schema(description = "반복 주기 (몇 주마다 등)", example = "1")
             int recurringInterval,
             @Schema(description = "반복 시작일", example = "2025-04-10")
-            LocalDate startAt,
+            LocalDate startDate,
             @Schema(description = "반복 종료일", example = "2025-06-10")
-            LocalDate endAt
-    ) {}
+            LocalDate endDate
+    ) {
+        public com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules toCommand() {
+            return com.hhplus.project.domain.event.dto.UpdateEvent.RecurringRules.create(
+                    recurringRulesId,
+                    recurringType,
+                    recurringInterval,
+                    startDate,
+                    endDate
+            );
+        }
+
+    }
 }

--- a/src/test/java/com/hhplus/project/domain/EventServiceTest.java
+++ b/src/test/java/com/hhplus/project/domain/EventServiceTest.java
@@ -1,0 +1,119 @@
+package com.hhplus.project.domain;
+
+import com.hhplus.project.BaseIntegrationTest;
+import com.hhplus.project.domain.event.*;
+import com.hhplus.project.domain.event.dto.UpdateEvent;
+import com.hhplus.project.infra.event.entity.EventEntity;
+import com.hhplus.project.infra.event.repository.EventJpaRepository;
+import com.hhplus.project.support.BaseException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventServiceTest extends BaseIntegrationTest {
+
+    @Autowired
+    EventService eventService;
+
+    @Autowired
+    EventJpaRepository eventJpaRepository;
+
+    @Test
+    @DisplayName("이벤트 정보 변경 시 종료된 이벤트라면 예외를 발생한다")
+    void updateEndedEvent() {
+        // given
+        EventEntity event = EventEntity.create(
+                1L,
+                1L,
+                "서각코 모집",
+                "스타벅스에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 4, 10, 14, 0),
+                LocalDateTime.of(2025, 4, 10, 16, 0),
+                1L,
+                30,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "스타벅스 XX지점",
+                null,
+                null
+        );
+        Event savedEvent = eventJpaRepository.save(event).toDomain();
+
+        UpdateEvent.Command command = UpdateEvent.Command.create(
+                savedEvent.eventId(),
+                1L,
+                "서각코 모집(장소변경)",
+                "메가커피에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 4, 10, 14, 0),
+                LocalDateTime.of(2025, 4, 10, 16, 0),
+                50,
+                EventEnums.ApproveType.AUTO,
+                false,
+                1L,
+                "메가커피 **지점",
+                null,
+                null
+        );
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> eventService.update(command))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(EventException.ALREADY_ENDED_EVENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("이벤트 정보 변경 시 종료된 이벤트가 아니라면 이벤트 정보를 업데이트한다")
+    public void updateEvent() {
+        // given
+        EventEntity event = EventEntity.create(
+                1L,
+                1L,
+                "서각코 모집",
+                "스타벅스에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 12, 31, 14, 0),
+                LocalDateTime.of(2025, 12, 31, 16, 0),
+                1L,
+                30,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "스타벅스 XX지점",
+                null,
+                null
+        );
+        Event savedEvent = eventJpaRepository.save(event).toDomain();
+
+        UpdateEvent.Command command = UpdateEvent.Command.create(
+                savedEvent.eventId(),
+                1L,
+                "서각코 모집(장소변경)",
+                "메가커피에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 12, 31, 20, 0),
+                LocalDateTime.of(2025, 12, 31, 22, 0),
+                50,
+                EventEnums.ApproveType.AUTO,
+                false,
+                1L,
+                "메가커피 **지점",
+                null,
+                null
+        );
+
+        eventService.update(command);
+
+        // when
+        EventEntity eventEntity = eventJpaRepository.findById(savedEvent.eventId()).get();
+
+        // then
+        assertThat(eventEntity)
+                .extracting("eventId", "categoryId", "name", "content", "startAt", "endAt", "capacity", "locationId", "locationDetail")
+                 .containsExactly(command.eventId(), command.categoryId(), command.name(), command.content(), command.startAt(), command.endAt(), command.capacity(), command.locationId(), command.locationDetail());
+    }
+
+
+
+}

--- a/src/test/java/com/hhplus/project/domain/EventUnitTest.java
+++ b/src/test/java/com/hhplus/project/domain/EventUnitTest.java
@@ -1,0 +1,106 @@
+package com.hhplus.project.domain;
+
+import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.domain.event.EventEnums;
+import com.hhplus.project.domain.event.EventException;
+import com.hhplus.project.domain.event.dto.UpdateEvent;
+import com.hhplus.project.support.BaseException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventUnitTest {
+
+    @Test
+    @DisplayName("이벤트 정보 변경 시 종료된 이벤트라면 예외를 발생한다")
+    public void updateEndedEvent() {
+        // given
+        Event event = Event.create(
+                1L,
+                1L,
+                1L,
+                "서각코 모집",
+                "스타벅스에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 4, 10, 14, 0),
+                LocalDateTime.of(2025, 4, 10, 16, 0),
+                1L,
+                30,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "스타벅스 XX지점",
+                null,
+                null
+        );
+
+        UpdateEvent.Command command = UpdateEvent.Command.create(
+                1L,
+                1L,
+                "서각코 모집(장소변경)",
+                "메가커피에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 4, 10, 14, 0),
+                LocalDateTime.of(2025, 4, 10, 16, 0),
+                50,
+                EventEnums.ApproveType.AUTO,
+                false,
+                1L,
+                "메가커피 **지점",
+                null,
+                null
+        );
+
+        // when // then
+        Assertions.assertThatThrownBy(() -> event.update(command, null))
+                .isInstanceOf(BaseException.class)
+                .hasMessage(EventException.ALREADY_ENDED_EVENT.getMessage());
+    }
+
+    @Test
+    @DisplayName("이벤트 정보 변경 시 종료된 이벤트가 아니라면 바뀐 이벤트 정보를 세팅하여 반환한다")
+    public void updateEvent() {
+        Event event = Event.create(
+                1L,
+                1L,
+                1L,
+                "서각코 모집",
+                "스타벅스에서 모각코 하실 분!",
+                LocalDateTime.of(2999, 12, 31, 14, 0),
+                LocalDateTime.of(2999, 12, 31, 16, 0),
+                1L,
+                30,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "스타벅스 XX지점",
+                null,
+                null
+        );
+
+        // given
+        UpdateEvent.Command command = UpdateEvent.Command.create(
+                1L,
+                2L,
+                "서각코 모집(장소변경)",
+                "메가커피에서 모각코 하실 분!",
+                LocalDateTime.of(2999, 12, 31, 20, 0),
+                LocalDateTime.of(2999, 12, 31, 21, 0),
+                50,
+                EventEnums.ApproveType.AUTO,
+                false,
+                2L,
+                "메가커피 **지점",
+                null,
+                null
+        );
+
+        // when
+        Event updatedEvent = event.update(command, null);
+
+        // then
+        assertThat(updatedEvent)
+                .extracting("categoryId", "name", "content", "startAt", "endAt", "capacity", "locationId", "locationDetail")
+                .containsExactly(command.categoryId(), command.name(), command.content(), command.startAt(), command.endAt(), command.capacity(), command.locationId(), command.locationDetail());
+    }
+}

--- a/src/test/java/com/hhplus/project/infra/entity/EventEntityUnitTest.java
+++ b/src/test/java/com/hhplus/project/infra/entity/EventEntityUnitTest.java
@@ -1,0 +1,61 @@
+package com.hhplus.project.infra.entity;
+
+import com.hhplus.project.domain.event.Event;
+import com.hhplus.project.domain.event.EventEnums;
+import com.hhplus.project.infra.event.entity.EventEntity;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EventEntityUnitTest {
+
+    @Test
+    @DisplayName("이벤트 도메인 모델 정보로 이벤트 JPA 엔티티 정보를 변경한다")
+    public void updateEventEntity() {
+        // given
+        EventEntity eventEntity = EventEntity.create(
+                1L,
+                1L,
+                "서각코 모집",
+                "스타벅스에서 모각코 하실 분!",
+                LocalDateTime.of(2025, 4, 10, 14, 0),
+                LocalDateTime.of(2025, 4, 10, 16, 0),
+                1L,
+                30,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "스타벅스 XX지점",
+                null,
+                null
+        );
+
+        Event event = Event.create(
+                1L,
+                2L,
+                2L,
+                "서각코 모집(장소변경)",
+                "메가커피에서 모각코 하실 분!",
+                LocalDateTime.of(2999, 12, 31, 20, 0),
+                LocalDateTime.of(2999, 12, 31, 21, 0),
+                1L,
+                50,
+                EventEnums.ApproveType.AUTO,
+                false,
+                "메가커피 **지점",
+                null,
+                null
+        );
+
+        // when
+        eventEntity.update(event, null);
+
+        // then
+        assertThat(eventEntity)
+                .extracting("categoryId", "name", "content", "startAt", "endAt", "capacity", "locationId", "locationDetail")
+                .containsExactly(event.categoryId(), event.name(), event.content(), event.startAt(), event.endAt(), event.capacity(), event.locationId(), event.locationDetail());
+
+    }
+}

--- a/src/test/java/com/hhplus/project/interfaces/event/EventControllerTest.java
+++ b/src/test/java/com/hhplus/project/interfaces/event/EventControllerTest.java
@@ -85,12 +85,12 @@ class EventControllerTest extends BaseIntegrationTest {
 
     @Test
     @DisplayName("이벤트 정보 수정 API 호출 시, 정상 응답(HTTP 200)이 반환되는지 확인한다.")
-    void updateEvent() {
+    void updateEvent() throws JsonProcessingException {
         // given
         long eventId = 1L;
 
         UpdateEvent.Request request = new UpdateEvent.Request(
-                123L,
+                1L,
                 "서각코 모집",
                 "스타벅스에서 모각코 하실 분!",
                 LocalDateTime.of(2025, 4, 10, 14, 0),
@@ -98,16 +98,22 @@ class EventControllerTest extends BaseIntegrationTest {
                 30,
                 EventEnums.ApproveType.AUTO,
                 false,
-                12L,
+                1L,
                 "스타벅스 XX지점",
                 null
         );
 
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+        String json = objectMapper.writeValueAsString(request);
+
         // when
         ExtractableResponse<Response> response = RestAssured
                 .given()
+                .multiPart("request", "request.json", json, "application/json")
                 .contentType(ContentType.MULTIPART)
-                .body(request)
                 .when()
                 .patch("/events/" + eventId)
                 .then()

--- a/src/test/java/com/hhplus/project/interfaces/event/EventControllerTest.java
+++ b/src/test/java/com/hhplus/project/interfaces/event/EventControllerTest.java
@@ -88,7 +88,7 @@ class EventControllerTest extends BaseIntegrationTest {
     void updateEvent() {
         // given
         long eventId = 1L;
-        UpdateEvent.EventImage eventImage = new UpdateEvent.EventImage(234L, "sample.jpg");
+
         UpdateEvent.Request request = new UpdateEvent.Request(
                 123L,
                 "서각코 모집",
@@ -100,14 +100,13 @@ class EventControllerTest extends BaseIntegrationTest {
                 false,
                 12L,
                 "스타벅스 XX지점",
-                eventImage,
                 null
         );
 
         // when
         ExtractableResponse<Response> response = RestAssured
                 .given()
-                .contentType(ContentType.JSON)
+                .contentType(ContentType.MULTIPART)
                 .body(request)
                 .when()
                 .patch("/events/" + eventId)


### PR DESCRIPTION
## PR 유형

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 요약

* 이벤트 수정 로직 개발
* 도메인 모델 단위 테스트, 도메인 서비스 통합 테스트, jpa 엔티티 단위 테스트 작성

## To Reviewer
이벤트 정보  수정 시 **dto -> dto 정보로 Event 도메일 모델 정보 업데이트 -> event 도메인 모델 정보로 EventEntity 정보 업데이트**  흐름으로 동작합니다.  

EventEntity 정보 업데이트 시 더티 체킹이 동작하지 않아 EventRepositoryImpl save() 메서드에서 이벤트를 한번 조회 후 정보를 업데이트해서 더티 체킹을 이용해 저장하는데 이 방법이 적절한지 피드백 부탁드립니다. a7849015f3ddafbfb98c59257fb0726c75ceb163 
